### PR TITLE
allowing group by columns to match constants

### DIFF
--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/AggregateIndexMatchCandidate.java
@@ -337,7 +337,7 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
         final var resultType = groupByResultValue.getResultType();
         final var messageBuilder = TypeRepository.newBuilder().addTypeIfNeeded(resultType).build().newMessageBuilder(resultType);
         final var messageDescriptor = Objects.requireNonNull(messageBuilder).getDescriptorForType();
-        final var constraintMaybe = partialMatch.getMatchInfo().getConstraintMaybe();
+        final var constraintMaybe = partialMatch.getMatchInfo().getConstraint();
 
         final var indexEntryConverter = createIndexEntryConverter(messageDescriptor);
         final var aggregateIndexScan = new RecordQueryIndexPlan(index.getName(),
@@ -355,7 +355,7 @@ public class AggregateIndexMatchCandidate implements MatchCandidate, WithBaseQua
                 recordTypes.get(0).getName(),
                 indexEntryConverter,
                 groupByResultValue,
-                constraintMaybe.orElse(QueryPlanConstraint.tautology()));
+                constraintMaybe);
     }
 
     @Nonnull

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchInfo.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/MatchInfo.java
@@ -63,7 +63,7 @@ public class MatchInfo {
      * Conjuncts the constraints from the predicate map into a single {@link QueryPlanConstraint}.
      */
     @Nonnull
-    private final Supplier<Optional<QueryPlanConstraint>> capturedConstraintsSupplier;
+    private final Supplier<QueryPlanConstraint> constraintsSupplier;
 
     @Nonnull
     private final PredicateMap predicateMap;
@@ -85,11 +85,17 @@ public class MatchInfo {
     private final Optional<Value> remainingComputationValueOptional;
 
     /**
-     * a map of maximum matches between the query result {@code Value} and the corresponding candidate's result
+     * A map of maximum matches between the query result {@code Value} and the corresponding candidate's result
      * {@code Value}.
      */
     @Nonnull
     private final Optional<MaxMatchMap> maxMatchMapOptional;
+
+    /**
+     * Field to hold additional query plan constraints that need to be imposed on the potentially realized match.
+     */
+    @Nonnull
+    private final QueryPlanConstraint additionalPlanConstraint;
 
     private MatchInfo(@Nonnull final Map<CorrelationIdentifier, ComparisonRange> parameterBindingMap,
                       @Nonnull final IdentityBiMap<Quantifier, PartialMatch> quantifierToPartialMatchMap,
@@ -97,7 +103,8 @@ public class MatchInfo {
                       @Nonnull final PredicateMap accumulatedPredicateMap,
                       @Nonnull final List<MatchedOrderingPart> matchedOrderingParts,
                       @Nonnull final Optional<Value> remainingComputationValueOptional,
-                      @Nonnull final Optional<MaxMatchMap> maxMatchMapOptional) {
+                      @Nonnull final Optional<MaxMatchMap> maxMatchMapOptional,
+                      @Nonnull final QueryPlanConstraint additionalPlanConstraint) {
         this.parameterBindingMap = ImmutableMap.copyOf(parameterBindingMap);
         this.quantifierToPartialMatchMap = quantifierToPartialMatchMap.toImmutable();
         this.aliasToPartialMatchMapSupplier = Suppliers.memoize(() -> {
@@ -106,7 +113,7 @@ public class MatchInfo {
             return mapBuilder.build();
         });
         this.accumulatedPredicateMap = accumulatedPredicateMap;
-        this.capturedConstraintsSupplier = Suppliers.memoize(this::capturedConstraintCollectorMaybe);
+        this.constraintsSupplier = Suppliers.memoize(this::computeConstraints);
         this.predicateMap = predicateMap;
         this.accumulatedPredicateMapSupplier = Suppliers.memoize(() -> {
             final PredicateMap.Builder targetBuilder = PredicateMap.builder();
@@ -117,6 +124,7 @@ public class MatchInfo {
         this.matchedOrderingParts = ImmutableList.copyOf(matchedOrderingParts);
         this.remainingComputationValueOptional = remainingComputationValueOptional;
         this.maxMatchMapOptional = maxMatchMapOptional;
+        this.additionalPlanConstraint = additionalPlanConstraint;
     }
 
     @Nonnull
@@ -145,8 +153,8 @@ public class MatchInfo {
     }
 
     @Nonnull
-    public Optional<QueryPlanConstraint> getConstraintMaybe() {
-        return capturedConstraintsSupplier.get();
+    public QueryPlanConstraint getConstraint() {
+        return constraintsSupplier.get();
     }
 
     @Nonnull
@@ -180,6 +188,11 @@ public class MatchInfo {
     }
 
     @Nonnull
+    public QueryPlanConstraint getAdditionalPlanConstraint() {
+        return additionalPlanConstraint;
+    }
+
+    @Nonnull
     public MatchInfo withOrderingInfo(@Nonnull final List<MatchedOrderingPart> matchedOrderingParts) {
         return new MatchInfo(parameterBindingMap,
                 quantifierToPartialMatchMap,
@@ -187,29 +200,33 @@ public class MatchInfo {
                 accumulatedPredicateMap,
                 matchedOrderingParts,
                 remainingComputationValueOptional,
-                maxMatchMapOptional);
+                maxMatchMapOptional,
+                additionalPlanConstraint);
     }
 
     @Nonnull
-    private Optional<QueryPlanConstraint> capturedConstraintCollectorMaybe() {
+    private QueryPlanConstraint computeConstraints() {
         final var childConstraints = quantifierToPartialMatchMap.values().stream().map(
-                partialMatch -> partialMatch.get().getMatchInfo().capturedConstraintCollectorMaybe()).flatMap(Optional::stream).collect(Collectors.toList());
+                partialMatch -> partialMatch.get().getMatchInfo().getConstraint()).collect(Collectors.toList());
         final var constraints = predicateMap.getMap()
                 .values()
                 .stream()
                 .map(PredicateMultiMap.PredicateMapping::getConstraint)
                 .collect(Collectors.toUnmodifiableList());
-        if (constraints.isEmpty() && childConstraints.isEmpty()) {
-            return Optional.empty();
-        }
-        final var allConstraints = ImmutableList.<QueryPlanConstraint>builder().addAll(constraints).addAll(childConstraints).build();
-        return Optional.of(QueryPlanConstraint.composeConstraints(allConstraints));
+        final var allConstraints =
+                ImmutableList.<QueryPlanConstraint>builder()
+                        .addAll(constraints)
+                        .addAll(childConstraints)
+                        .add(additionalPlanConstraint)
+                        .build();
+        return QueryPlanConstraint.composeConstraints(allConstraints);
     }
 
     @Nonnull
     public static Optional<MatchInfo> tryFromMatchMap(@Nonnull final IdentityBiMap<Quantifier, PartialMatch> partialMatchMap,
                                                       @Nonnull final Optional<MaxMatchMap> maxMatchMap) {
-        return tryMerge(partialMatchMap, ImmutableMap.of(), PredicateMap.empty(), PredicateMap.empty(), Optional.empty(), maxMatchMap);
+        return tryMerge(partialMatchMap, ImmutableMap.of(), PredicateMap.empty(), PredicateMap.empty(),
+                Optional.empty(), maxMatchMap, QueryPlanConstraint.tautology());
     }
 
     @Nonnull
@@ -218,7 +235,8 @@ public class MatchInfo {
                                                @Nonnull final PredicateMap predicateMap,
                                                @Nonnull final PredicateMap accumulatedPredicateMap,
                                                @Nonnull final Optional<Value> remainingComputationValueOptional,
-                                               @Nonnull final Optional<MaxMatchMap> maxMatchMap) {
+                                               @Nonnull final Optional<MaxMatchMap> maxMatchMap,
+                                               @Nonnull final QueryPlanConstraint additionalPlanConstraint) {
         final var parameterMapsBuilder = ImmutableList.<Map<CorrelationIdentifier, ComparisonRange>>builder();
         final var matchInfos = PartialMatch.matchInfosFromMap(partialMatchMap);
 
@@ -261,7 +279,8 @@ public class MatchInfo {
                         accumulatedPredicateMap,
                         orderingParts,
                         remainingComputationValueOptional,
-                        maxMatchMap));
+                        maxMatchMap,
+                        additionalPlanConstraint));
     }
 
     public static Optional<Map<CorrelationIdentifier, ComparisonRange>> tryMergeParameterBindings(final Collection<Map<CorrelationIdentifier, ComparisonRange>> parameterBindingMaps) {

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexScanMatchCandidate.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/ValueIndexScanMatchCandidate.java
@@ -28,7 +28,6 @@ import com.apple.foundationdb.record.provider.foundationdb.IndexScanComparisons;
 import com.apple.foundationdb.record.provider.foundationdb.IndexScanParameters;
 import com.apple.foundationdb.record.query.plan.AvailableFields;
 import com.apple.foundationdb.record.query.plan.IndexKeyValueToPartialRecord;
-import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.ScanComparisons;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.values.FieldValue;
@@ -239,10 +238,9 @@ public class ValueIndexScanMatchCandidate implements ScanWithFetchMatchCandidate
                                 false,
                                 partialMatch.getMatchCandidate(),
                                 baseRecordType,
-                                matchInfo.getConstraintMaybe().orElse(QueryPlanConstraint.tautology())));
+                                matchInfo.getConstraint()));
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     @Nonnull
     private Optional<RecordQueryPlan> tryFetchCoveringIndexScan(@Nonnull final PartialMatch partialMatch,
                                                                 @Nonnull final PlanContext planContext,
@@ -260,7 +258,7 @@ public class ValueIndexScanMatchCandidate implements ScanWithFetchMatchCandidate
         for (int i = 0; i < indexKeyValues.size(); i++) {
             final Value keyValue = indexKeyValues.get(i);
             if (keyValue instanceof FieldValue && keyValue.isFunctionallyDependentOn(baseObjectValue)) {
-                @SuppressWarnings("UnstableApiUsage") final AvailableFields.FieldData fieldData =
+                final AvailableFields.FieldData fieldData =
                         AvailableFields.FieldData.ofUnconditional(IndexKeyValueToPartialRecord.TupleSource.KEY, ImmutableIntArray.of(i));
                 if (!addCoveringField(builder, (FieldValue)keyValue, fieldData)) {
                     return Optional.empty();
@@ -294,7 +292,7 @@ public class ValueIndexScanMatchCandidate implements ScanWithFetchMatchCandidate
                         false,
                         partialMatch.getMatchCandidate(),
                         baseRecordType,
-                        partialMatch.getMatchInfo().getConstraintMaybe().orElse(QueryPlanConstraint.tautology()));
+                        partialMatch.getMatchInfo().getConstraint());
 
         final RecordQueryCoveringIndexPlan coveringIndexPlan = new RecordQueryCoveringIndexPlan(indexPlan,
                 recordType.getName(),

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/SelectExpression.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/expressions/SelectExpression.java
@@ -24,6 +24,7 @@ import com.apple.foundationdb.annotation.API;
 import com.apple.foundationdb.record.EvaluationContext;
 import com.apple.foundationdb.record.query.combinatorics.CrossProduct;
 import com.apple.foundationdb.record.query.combinatorics.PartiallyOrderedSet;
+import com.apple.foundationdb.record.query.plan.QueryPlanConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.AliasMap;
 import com.apple.foundationdb.record.query.plan.cascades.ComparisonRange;
 import com.apple.foundationdb.record.query.plan.cascades.Compensation;
@@ -409,8 +410,9 @@ public class SelectExpression implements RelationalExpressionWithChildren.Childr
                     .stream()
                     .allMatch(QueryPredicate::isTautology);
             if (allNonFiltering) {
-                return MatchInfo.tryMerge(partialMatchMap, mergedParameterBindingMap, PredicateMap.empty(), PredicateMap.empty(), remainingValueComputationOptional, Optional.empty())
-                                .map(ImmutableList::of)
+                return MatchInfo.tryMerge(partialMatchMap, mergedParameterBindingMap, PredicateMap.empty(), PredicateMap.empty(),
+                                remainingValueComputationOptional, Optional.empty(), QueryPlanConstraint.tautology())
+                        .map(ImmutableList::of)
                                 .orElse(ImmutableList.of());
             } else {
                 return ImmutableList.of();
@@ -518,7 +520,8 @@ public class SelectExpression implements RelationalExpressionWithChildren.Childr
                                 return allParameterBindingMapOptional
                                         .flatMap(allParameterBindingMap -> MatchInfo.tryMerge(partialMatchMap,
                                                 allParameterBindingMap, predicateMap, PredicateMap.empty(),
-                                                remainingValueComputationOptional, Optional.empty()))
+                                                remainingValueComputationOptional, Optional.empty(),
+                                                QueryPlanConstraint.tautology()))
                                         .map(ImmutableList::of)
                                         .orElse(ImmutableList.of());
                             })

--- a/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
+++ b/fdb-record-layer-core/src/main/java/com/apple/foundationdb/record/query/plan/cascades/values/FieldValue.java
@@ -40,6 +40,7 @@ import com.apple.foundationdb.record.query.plan.cascades.BooleanWithConstraint;
 import com.apple.foundationdb.record.query.plan.cascades.Formatter;
 import com.apple.foundationdb.record.query.plan.cascades.NullableArrayTypeUtils;
 import com.apple.foundationdb.record.query.plan.cascades.SemanticException;
+import com.apple.foundationdb.record.query.plan.cascades.ValueEquivalence;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type;
 import com.apple.foundationdb.record.query.plan.cascades.typing.Type.Record.Field;
 import com.google.auto.service.AutoService;
@@ -184,18 +185,18 @@ public class FieldValue extends AbstractValue implements ValueWithChild {
                 .filter(ignored -> fieldPath.equals(((FieldValue)other).getFieldPath()));
     }
 
+    @Nonnull
     @Override
-    public boolean subsumedBy(@Nullable final Value other, @Nonnull final AliasMap equivalenceMap) {
-        if (other == null) {
-            return false;
-        }
+    public BooleanWithConstraint subsumedBy(@Nullable final Value other, @Nonnull final ValueEquivalence valueEquivalence) {
+        // delegate to semanticEquals()
+        return semanticEquals(other, valueEquivalence);
+    }
 
-        if (!(other instanceof FieldValue)) {
-            return false;
-        }
-        final var otherFieldValue = (FieldValue)other;
-        return fieldPath.getFieldOrdinals().equals(otherFieldValue.getFieldPath().getFieldOrdinals()) &&
-                childValue.subsumedBy(otherFieldValue.childValue, equivalenceMap);
+    @Override
+    @Nonnull
+    public BooleanWithConstraint subsumedByWithoutChildren(@Nonnull final Value other) {
+        return super.subsumedByWithoutChildren(other)
+                .compose(ignored -> equalsWithoutChildren(other));
     }
 
     @Override


### PR DESCRIPTION
- new field `additionalPlanConstraint` in `MatchInfo` that can be used by any matching logic creating a new `MatchInfo`
- refactored `subsumedBy()` in `Value` to work with `BooleanWithConstraint`
- improved matching logic in `GroupByExpression.subsumedBy()` to create a `ValueEquivalence` to match the grouping columns.